### PR TITLE
feat: add affected routes and stops on dto s and add trips client to …

### DIFF
--- a/src/incidents/dto/create-incident.dto.ts
+++ b/src/incidents/dto/create-incident.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsEnum, IsNumber } from 'class-validator';
+import { IsString, IsNotEmpty, IsEnum, IsNumber, IsArray, IsOptional } from 'class-validator';
 import { IncidentStatus } from 'src/models/enums/enums';
 import { IncidentPriority } from 'src/models/enums/enums';
 export class CreateIncidentDto {
@@ -39,5 +39,15 @@ export class CreateIncidentDto {
 
     @IsEnum(IncidentPriority)
     priority: string;
+
+    @IsArray()
+    @IsNumber({}, { each: true })
+    @IsOptional()
+    affectedStopIds?: number[];
+
+    @IsArray()
+    @IsNumber({}, { each: true })
+    @IsOptional()
+    affectedRouteIds?: number[];
 
 }

--- a/src/incidents/incidents.module.ts
+++ b/src/incidents/incidents.module.ts
@@ -20,6 +20,15 @@ import { CategoryEntity } from '../models/entity/category.entity';
           queueOptions: { durable: false },
         },
       },
+      {
+        name: 'TRIPS_SERVICE',
+        transport: Transport.RMQ,
+        options: {
+          urls: [process.env.RABBIT_MQ ?? 'amqp://localhost:5672'],
+          queue: 'INCIDENTS_QUEUE',
+          queueOptions: { durable: true },
+        },
+      },
     ]),
   ],
   controllers: [IncidentsController],

--- a/src/incidents/incidents.service.ts
+++ b/src/incidents/incidents.service.ts
@@ -20,6 +20,8 @@ export class IncidentsService {
     private readonly categoryRepository: Repository<CategoryEntity>,
     @Inject('NOTIFICATIONS_SERVICE')
     private readonly notificationsClient: ClientProxy,
+    @Inject('TRIPS_SERVICE')
+    private readonly tripsClient: ClientProxy,
   ) {}
 
   async create(createIncidentDto: CreateIncidentDto) {
@@ -35,6 +37,16 @@ export class IncidentsService {
 
     const incident = this.incidentRepository.create(createIncidentDto);
     const saved = await this.incidentRepository.save(incident);
+
+    this.tripsClient.emit('incident.created', {
+      incidentId: saved.id,
+      siteId: saved.siteId,
+      estimateDuration: saved.estimateDuration,
+      priority: saved.priority,
+      status: saved.status,
+      affectedStopIds: createIncidentDto.affectedStopIds ?? [],
+      affectedRouteIds: createIncidentDto.affectedRouteIds ?? [],
+    });
 
     this.notificationsClient.emit('notifications.sendEmail', {
       email: process.env.NOTIFICATION_DEFAULT_EMAIL ?? 'urban.flow.moselle@gmail.com',


### PR DESCRIPTION
…send incident to trips service 

Le each: true après le @IsNumber permet d'avoir uniquement des nombre "donc des ids valable" dans le tableau pour éviter quelque chose comme [1, "lol", "i'm blue"]

Le message du nouveau incident est bien en attente dans la queue ce qui est normal

Je dois voir encore avec Mathias comment il veut faire quand il reçois les incidents et voir si je dois rajouter des choses si nécessaires. 


